### PR TITLE
Add sentry + sidekiq fixes

### DIFF
--- a/lib/lamian/raven_context_extension.rb
+++ b/lib/lamian/raven_context_extension.rb
@@ -6,8 +6,6 @@ module Lamian::RavenContextExtension
   # @see https://www.rubydoc.info/gems/sentry-raven/0.9.2/Raven/Context#extra-instance_method
   def extra
     log = Lamian.dump(format: :txt)
-    return super unless log
-    extra = super || {}
-    extra.merge(lamian_log: log)
+    log ? super.merge!(lamian_log: log) : super
   end
 end

--- a/lib/lamian/sidekiq_raven_middleware.rb
+++ b/lib/lamian/sidekiq_raven_middleware.rb
@@ -8,7 +8,7 @@ class Lamian::SidekiqRavenMiddleware
       begin
         yield
       rescue Exception # rubocop:disable Lint/RescueException
-        Raven.extra_context(lamian_log: Lamian.dump(format: :txt))
+        Raven.extra_context # Just trigger saving of the current log
         raise
       end
     end

--- a/lib/lamian/version.rb
+++ b/lib/lamian/version.rb
@@ -13,5 +13,5 @@ module Lamian
   # According to this, it is enought to specify '~> a.b'
   # if private API was not used and to specify '~> a.b.c' if it was
 
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end

--- a/spec/lamian/raven_context_extension_spec.rb
+++ b/spec/lamian/raven_context_extension_spec.rb
@@ -1,18 +1,8 @@
 # frozen_string_literal: true
 
-require "raven"
-require "raven/transports/dummy"
-
-Raven::Context.prepend(Lamian::RavenContextExtension)
-
-Raven.configure do |config|
-  config.dsn = "dummy://public@example.com/project-id"
-  config.encoding = "json"
-  config.logger = Logger.new(nil)
-end
-
 describe Lamian::RavenContextExtension, :cool_loggers do
   after { sent_events.clear }
+  after { Raven::Context.clear! }
 
   let(:sent_events) { Raven.client.transport.events }
   let(:extra_info) { JSON.parse(sent_events.last[1]).fetch("extra") }

--- a/spec/lamian/sidekiq_raven_middleware_spec.rb
+++ b/spec/lamian/sidekiq_raven_middleware_spec.rb
@@ -2,11 +2,10 @@
 
 describe Lamian::SidekiqRavenMiddleware, :cool_loggers do
   it "call Raven.extra_context with proper lamian_log" do
-    expect(Raven).to receive(:extra_context).with(lamian_log: "some log\n")
+    expect(Raven).to receive(:extra_context)
 
     middleware_call = proc do
       Lamian::SidekiqRavenMiddleware.new.call do
-        generic_logger.info "some log"
         raise "some error"
       end
     end

--- a/spec/lamian/sidekiq_raven_middleware_spec.rb
+++ b/spec/lamian/sidekiq_raven_middleware_spec.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
 
 describe Lamian::SidekiqRavenMiddleware, :cool_loggers do
-  it "call Raven.extra_context with proper lamian_log" do
-    expect(Raven).to receive(:extra_context)
-
+  it "calls Raven.extra_context and adds Lamian.run" do
     middleware_call = proc do
       Lamian::SidekiqRavenMiddleware.new.call do
+        generic_logger.info "some log"
         raise "some error"
       end
     end
 
+    expect(Raven.extra_context).not_to have_key(:lamian_log)
     expect(middleware_call).to raise_error(RuntimeError, "some error")
+    expect(Raven.extra_context[:lamian_log]).to eq("some log\n")
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,24 +9,8 @@ Coveralls.wear!
 
 require "lamian"
 
-require_relative "support/raven"
+Dir[File.join(__dir__, "support/**/*.rb")].each { |x| require(x) }
 
 RSpec.configure do |config|
   config.order = :random
-end
-
-shared_context "cool loggers", :cool_loggers do
-  let(:generic_logger_buffer) { StringIO.new }
-  let(:generic_logger) { ::Logger.new(generic_logger_buffer) }
-
-  let(:cool_formatter) do
-    -> (_severity, _date, _progname, message) { "#{message}\n" }
-  end
-
-  before("extend generic_logger") { Lamian.extend_logger(generic_logger) }
-
-  before("stub formatter") do
-    allow(Lamian.config).to receive(:formatter).and_return(cool_formatter)
-    generic_logger.formatter = cool_formatter
-  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,8 @@ Coveralls.wear!
 
 require "lamian"
 
+require_relative "support/raven"
+
 RSpec.configure do |config|
   config.order = :random
 end

--- a/spec/support/cool_loggers.rb
+++ b/spec/support/cool_loggers.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+shared_context "cool loggers", :cool_loggers do
+  let(:generic_logger_buffer) { StringIO.new }
+  let(:generic_logger) { ::Logger.new(generic_logger_buffer) }
+
+  let(:cool_formatter) do
+    -> (_severity, _date, _progname, message) { "#{message}\n" }
+  end
+
+  before("extend generic_logger") { Lamian.extend_logger(generic_logger) }
+
+  before("stub formatter") do
+    allow(Lamian.config).to receive(:formatter).and_return(cool_formatter)
+    generic_logger.formatter = cool_formatter
+  end
+end

--- a/spec/support/raven.rb
+++ b/spec/support/raven.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "raven"
+require "raven/transports/dummy"
+
+Raven::Context.prepend(Lamian::RavenContextExtension)
+
+Raven.configure do |config|
+  config.dsn = "dummy://public@example.com/project-id"
+  config.encoding = "json"
+  config.logger = Logger.new(nil)
+end


### PR DESCRIPTION
1. Creating new hash in `Lamian::RavenContextExtension` was a mistake, we should modify the existing one (that's how `Raven.extra_context` works).
2. Passing the log in `Lamian::SidekiqRavenMiddleware` is not required, because it calls the `Lamian::RavenContextExtension#extra` method anyway.
3. Fixed specs sometimes failing because raven is not required.