### PR TITLE
Add sentry_log_size_limit config param

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,9 @@ Update this on a pull request, under `Lamian::VERSION`
 (also known as next version). If this constant would be changed without release,
 I'll update it here too
 
+## 1.2.0
+* Add `raven_log_size_limit` config option for limiting amount of data sent to sentry (defaults to `500_000`)
+
 ## 1.1.0
 * Add support for sentry and sidekiq
 

--- a/lib/lamian/config.rb
+++ b/lib/lamian/config.rb
@@ -6,9 +6,12 @@ module Lamian
   # General lamian configuration class
   # @attr formatter [Logger::Foramtter]
   #   formatter to use in lamian, global
-  Config = Struct.new(:formatter) do
+  # @attr sentry_log_size_limit [Integer]
+  #   size limit when sending lamian log to sentry, defaults to +500_000+
+  Config = Struct.new(:formatter, :sentry_log_size_limit) do
     def initialize
       self.formatter = ::Logger::Formatter.new
+      self.sentry_log_size_limit = 500_000
     end
   end
 end

--- a/lib/lamian/config.rb
+++ b/lib/lamian/config.rb
@@ -6,12 +6,12 @@ module Lamian
   # General lamian configuration class
   # @attr formatter [Logger::Foramtter]
   #   formatter to use in lamian, global
-  # @attr sentry_log_size_limit [Integer]
+  # @attr raven_log_size_limit [Integer]
   #   size limit when sending lamian log to sentry, defaults to +500_000+
-  Config = Struct.new(:formatter, :sentry_log_size_limit) do
+  Config = Struct.new(:formatter, :raven_log_size_limit) do
     def initialize
       self.formatter = ::Logger::Formatter.new
-      self.sentry_log_size_limit = 500_000
+      self.raven_log_size_limit = 500_000
     end
   end
 end

--- a/lib/lamian/raven_context_extension.rb
+++ b/lib/lamian/raven_context_extension.rb
@@ -5,7 +5,7 @@ module Lamian::RavenContextExtension
   # Adds current lamian log to the extra part of all raven events generated inside Lamian.run block
   # @see https://www.rubydoc.info/gems/sentry-raven/0.9.2/Raven/Context#extra-instance_method
   def extra
-    log = Lamian.dump(format: :txt)
+    log = Lamian.dump(format: :txt)&.slice(0, Lamian.config.sentry_log_size_limit)
     log ? super.merge!(lamian_log: log) : super
   end
 end

--- a/lib/lamian/raven_context_extension.rb
+++ b/lib/lamian/raven_context_extension.rb
@@ -5,7 +5,7 @@ module Lamian::RavenContextExtension
   # Adds current lamian log to the extra part of all raven events generated inside Lamian.run block
   # @see https://www.rubydoc.info/gems/sentry-raven/0.9.2/Raven/Context#extra-instance_method
   def extra
-    log = Lamian.dump(format: :txt)&.slice(0, Lamian.config.sentry_log_size_limit)
+    log = Lamian.dump(format: :txt)&.slice(0, Lamian.config.raven_log_size_limit)
     log ? super.merge!(lamian_log: log) : super
   end
 end

--- a/lib/lamian/version.rb
+++ b/lib/lamian/version.rb
@@ -13,5 +13,5 @@ module Lamian
   # According to this, it is enought to specify '~> a.b'
   # if private API was not used and to specify '~> a.b.c' if it was
 
-  VERSION = "1.1.1"
+  VERSION = "1.2.0"
 end

--- a/spec/lamian/raven_context_extension_spec.rb
+++ b/spec/lamian/raven_context_extension_spec.rb
@@ -22,4 +22,17 @@ describe Lamian::RavenContextExtension, :cool_loggers do
       expect(extra_info).not_to have_key("lamian_log")
     end
   end
+
+  context "when sentry_log_size_limit is set" do
+    before { allow(Lamian.config).to receive(:sentry_log_size_limit).and_return(3) }
+
+    it "truncates the log" do
+      Lamian.run do
+        generic_logger.info "some log"
+        Raven.capture_message("msg")
+      end
+
+      expect(extra_info["lamian_log"]).to eq("som")
+    end
+  end
 end

--- a/spec/lamian/raven_context_extension_spec.rb
+++ b/spec/lamian/raven_context_extension_spec.rb
@@ -23,8 +23,8 @@ describe Lamian::RavenContextExtension, :cool_loggers do
     end
   end
 
-  context "when sentry_log_size_limit is set" do
-    before { allow(Lamian.config).to receive(:sentry_log_size_limit).and_return(3) }
+  context "when raven_log_size_limit is set" do
+    before { allow(Lamian.config).to receive(:raven_log_size_limit).and_return(3) }
 
     it "truncates the log" do
       Lamian.run do


### PR DESCRIPTION
It turns out that sentry has 200 KB limit for all events (see https://docs.sentry.io/clients/javascript/usage/)
So we only send first 500k characters (should work after gzipping in most cases).