### PR TITLE
Add support for the new Sentry gem

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,9 @@ Update this on a pull request, under `Lamian::VERSION`
 (also known as next version). If this constant would be changed without release,
 I'll update it here too
 
+## 1.3.0
+* Add support for the (new sentry gem)[https://github.com/getsentry/sentry-ruby].
+
 ## 1.2.0
 * Add `raven_log_size_limit` config option for limiting amount of data sent to sentry (defaults to `500_000`)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lamian (1.2.0)
+    lamian (1.3.0)
       rails (>= 4.2)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -21,7 +21,25 @@ Add a 'request_log' section into ExceptionNotification's background section.
 Add `Lamian.run { }` around code with logs you want to collect. Note, that
 logs would be accessible only inside this section and removed after section end.
 
-## Raven
+## Sentry (sentry-ruby)
+
+### Usage
+
+It automatically redefines `Sentry.configuration.before_send` callback
+if Sentry initialization is completed. If `before_send` is already defined
+it wraps custom callback.
+
+### Usage with Sidekiq
+
+You should add Lamian middleware to the Sidekiq initializer like this:
+
+```ruby
+config.server_middleware do |chain|
+  chain.prepend(Lamian::SidekiqSentryMiddleware)
+end
+```
+
+## Raven (deprecated)
 
 ### Usage
 
@@ -38,24 +56,6 @@ You should add Lamian middleware to the Sidekiq initializer like this:
 ```ruby
 config.server_middleware do |chain|
   chain.prepend(Lamian::SidekiqRavenMiddleware)
-end
-```
-
-## Sentry (sentry-ruby)
-
-### Usage
-
-It automatically redefines `Sentry.configuration.before_send` callback
-if Sentry initialization is completed. If `before_send` is already defined
-it wraps custom callback.
-
-### Usage with Sidekiq
-
-You should add Lamian middleware to the Sidekiq initializer like this:
-
-```ruby
-config.server_middleware do |chain|
-  chain.prepend(Lamian::SidekiqSentryMiddleware)
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,19 +21,41 @@ Add a 'request_log' section into ExceptionNotification's background section.
 Add `Lamian.run { }` around code with logs you want to collect. Note, that
 logs would be accessible only inside this section and removed after section end.
 
-## Usage with Raven (Sentry)
+## Raven
+
+### Usage
+
 Add this line to your Sentry initializer:
 
 ```ruby
 Raven::Context.prepend(Lamian::RavenContextExtension)
 ```
 
-## Usage with Sidekiq and Raven
+### Usage with Sidekiq
+
 You should add Lamian middleware to the Sidekiq initializer like this:
 
 ```ruby
 config.server_middleware do |chain|
   chain.prepend(Lamian::SidekiqRavenMiddleware)
+end
+```
+
+## Sentry (sentry-ruby)
+
+### Usage
+
+It automatically redefines `Sentry.configuration.before_send` callback
+if Sentry initialization is completed. If `before_send` is already defined
+it wraps custom callback.
+
+### Usage with Sidekiq
+
+You should add Lamian middleware to the Sidekiq initializer like this:
+
+```ruby
+config.server_middleware do |chain|
+  chain.prepend(Lamian::SidekiqSentryMiddleware)
 end
 ```
 

--- a/lib/lamian.rb
+++ b/lib/lamian.rb
@@ -12,6 +12,9 @@ module Lamian
   autoload :Middleware, "lamian/middleware"
   autoload :RavenContextExtension, "lamian/raven_context_extension"
   autoload :SidekiqRavenMiddleware, "lamian/sidekiq_raven_middleware"
+  autoload :SidekiqSentryMiddleware, "lamian/sidekiq_sentry_middleware"
+
+  SENTRY_EXTRA_KEY = :lamian_log
 
   require "lamian/engine"
 
@@ -50,13 +53,19 @@ module Lamian
     end
 
     # Dumps log collected in this run
-    # @option format [Symbol]
+    # @param format [Symbol]
     #   requested format of log. At this point, returns raw log if falsey
     #   or log without controll sequences (such as '[23m') if truthy
     #   value given (for now)
     # @return formatted log (String by default)
     def dump(format: nil)
       logger.dump(format: format)
+    end
+
+    # Truncates the collected log to the specified limit and dumps it.
+    # @return [String, nil] truncated formatted log.
+    def dump_limited
+      dump(format: :txt)&.slice(0, Lamian.config.raven_log_size_limit)
     end
   end
 end

--- a/lib/lamian/engine.rb
+++ b/lib/lamian/engine.rb
@@ -14,5 +14,35 @@ module Lamian
       app.config.middleware.unshift(Lamian::Middleware)
       # :nocov:
     end
+
+    config.after_initialize do
+      # :nocov:
+      next unless defined?(Sentry)
+      next unless Sentry.initialized?
+
+      Sentry.configuration.before_send = rebuild_before_send
+      # :nocov:
+    end
+
+    def rebuild_before_send
+      defined_callback = Sentry.configuration.before_send || build_default_lambda
+      lamian_callback = build_lamian_callback
+
+      proc { |*args, **kwargs| lamian_callback.call(defined_callback.call(*args, **kwargs)) }
+    end
+
+    def build_default_lambda
+      -> (event, _hint) { event }
+    end
+
+    def build_lamian_callback
+      lambda do |event|
+        event.tap do |event|
+          extra = event&.extra or return
+          log = Lamian.dump_limited
+          extra[Lamian::SENTRY_EXTRA_KEY] = log if log
+        end
+      end
+    end
   end
 end

--- a/lib/lamian/raven_context_extension.rb
+++ b/lib/lamian/raven_context_extension.rb
@@ -5,7 +5,7 @@ module Lamian::RavenContextExtension
   # Adds current lamian log to the extra part of all raven events generated inside Lamian.run block
   # @see https://www.rubydoc.info/gems/sentry-raven/0.9.2/Raven/Context#extra-instance_method
   def extra
-    log = Lamian.dump(format: :txt)&.slice(0, Lamian.config.raven_log_size_limit)
-    log ? super.merge!(lamian_log: log) : super
+    log = Lamian.dump_limited
+    log ? super.merge!(Lamian::SENTRY_EXTRA_KEY => log) : super
   end
 end

--- a/lib/lamian/sidekiq_sentry_middleware.rb
+++ b/lib/lamian/sidekiq_sentry_middleware.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# A sidekiq middleware
+class Lamian::SidekiqSentryMiddleware
+  # Adds current lamian log to the extra part of raven events generated inside sidekiq jobs
+  def call(*)
+    Lamian.run do
+      yield
+    rescue Exception # rubocop:disable Lint/RescueException
+      # Save current log
+      log = Lamian.dump_limited
+      Sentry.set_extras(Lamian::SENTRY_EXTRA_KEY => log) if log
+      raise
+    end
+  end
+end

--- a/lib/lamian/version.rb
+++ b/lib/lamian/version.rb
@@ -13,5 +13,5 @@ module Lamian
   # According to this, it is enought to specify '~> a.b'
   # if private API was not used and to specify '~> a.b.c' if it was
 
-  VERSION = "1.2.0"
+  VERSION = "1.3.0"
 end

--- a/spec/lamian/engine_spec.rb
+++ b/spec/lamian/engine_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+describe Lamian::Engine, :cool_loggers do
+  subject(:instance) { described_class.instance }
+
+  describe ".rebuild_before_send" do
+    let(:stubbed_event) do
+      instance_double(Sentry::Event).tap do |event|
+        allow(event).to receive(:extra).and_return(extra_hash)
+      end
+    end
+    let(:extra_hash) { Hash[] }
+
+    let(:callback) { instance.rebuild_before_send }
+
+    it "properly sets lamian_log" do
+      event = Lamian.run do
+        generic_logger.info "some log"
+        callback.call(stubbed_event, {})
+      end
+
+      expect(extra_hash).to include(:lamian_log)
+      expect(event).not_to eq(nil)
+    end
+
+    context "without logs" do
+      before { allow(Lamian).to receive(:dump_limited).and_return(nil) }
+
+      it "doesn't set lamian log" do
+        callback.call(stubbed_event, {})
+
+        expect(extra_hash).not_to include(:lamian_log)
+      end
+    end
+
+    context "when event is not returned" do
+      it "doesn't set lamian log" do
+        result = Lamian.run do
+          generic_logger.info "some log"
+          callback.call(nil, {})
+        end
+
+        expect(result).to eq(nil)
+        expect(extra_hash).not_to include(:lamian_log)
+      end
+    end
+  end
+end

--- a/spec/lamian/sidekiq_sentry_middleware_spec.rb
+++ b/spec/lamian/sidekiq_sentry_middleware_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+describe Lamian::SidekiqSentryMiddleware, :cool_loggers do
+  it "calls Sentry.set_extras and adds Lamian.run" do
+    middleware_call = proc do
+      Lamian::SidekiqSentryMiddleware.new.call do
+        generic_logger.info "some log"
+        raise "some error"
+      end
+    end
+
+    expect(Sentry.get_current_scope.extra).not_to have_key(:lamian_log)
+    expect(middleware_call).to raise_error(RuntimeError, "some error")
+    expect(Sentry.get_current_scope.extra[:lamian_log]).to eq("some log\n")
+  end
+end

--- a/spec/lamian/sidekiq_sentry_middleware_spec.rb
+++ b/spec/lamian/sidekiq_sentry_middleware_spec.rb
@@ -1,16 +1,32 @@
 # frozen_string_literal: true
 
 describe Lamian::SidekiqSentryMiddleware, :cool_loggers do
-  it "calls Sentry.set_extras and adds Lamian.run" do
-    middleware_call = proc do
+  around do |example|
+    Sentry.with_scope { example.call }
+  end
+
+  let(:middleware_call) do
+    proc do
       Lamian::SidekiqSentryMiddleware.new.call do
         generic_logger.info "some log"
         raise "some error"
       end
     end
+  end
 
-    expect(Sentry.get_current_scope.extra).not_to have_key(:lamian_log)
+  it "calls Sentry.set_extras and adds Lamian.run" do
+    expect(Sentry.get_current_scope.extra).not_to include(:lamian_log)
     expect(middleware_call).to raise_error(RuntimeError, "some error")
     expect(Sentry.get_current_scope.extra[:lamian_log]).to eq("some log\n")
+  end
+
+  context "without logs" do
+    before { allow(Lamian).to receive(:dump_limited).and_return(nil) }
+
+    it "doesn't set extras" do
+      expect(Sentry.get_current_scope.extra).not_to include(:lamian_log)
+      expect(middleware_call).to raise_error(RuntimeError, "some error")
+      expect(Sentry.get_current_scope.extra).not_to include(:lamian_log)
+    end
   end
 end

--- a/spec/support/sentry.rb
+++ b/spec/support/sentry.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "sentry-ruby"
+
+Sentry.init do |config|
+  config.dsn = "dummy://public@example.com/project-id"
+  config.logger = Logger.new(nil)
+end


### PR DESCRIPTION
# Changes

- Add `Lamian::dump_limited`
- Add support for [the new Sentry gem](https://github.com/getsentry/sentry-ruby) for both Sidekiq and Rails
- Write specs