### PR TITLE
Add sidekiq 6.5 support.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lamian (1.5.0)
+    lamian (1.6.0)
       rails (>= 4.2)
 
 GEM

--- a/lib/lamian/engine.rb
+++ b/lib/lamian/engine.rb
@@ -17,10 +17,13 @@ module Lamian
 
     config.after_initialize do
       # :nocov:
-      next unless defined?(Sentry)
-      next unless Sentry.initialized?
+      if defined?(Sentry) && Sentry.initialized?
+        Sentry.configuration.before_send = rebuild_before_send
+      end
 
-      Sentry.configuration.before_send = rebuild_before_send
+      if defined?(Sidekiq::ServerMiddleware)
+        Lamian::SidekiqSentryMiddleware.include(Sidekiq::ServerMiddleware)
+      end
       # :nocov:
     end
 

--- a/lib/lamian/version.rb
+++ b/lib/lamian/version.rb
@@ -13,5 +13,5 @@ module Lamian
   # According to this, it is enought to specify '~> a.b'
   # if private API was not used and to specify '~> a.b.c' if it was
 
-  VERSION = "1.5.0"
+  VERSION = "1.6.0"
 end


### PR DESCRIPTION
According to sidekiq middleware [changes](https://github.com/mperham/sidekiq/blob/main/docs/middleware.md) we have to include `Sidekiq::ClientMiddleware` module into any its own middleware.