### PR TITLE
Limit number of log lines stored in memory

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,19 +1,21 @@
-# Lamian version changes (since 0.1.0)
+## 1.9.0
 
-Update this on a pull request, under `Lamian::VERSION`
-(also known as next version). If this constant would be changed without release,
-I'll update it here too
+* Add `max_log_lines` config option to limit number of most recent log lines stored in the log device
 
 ## 1.8.0
+
 * Minor dependency updates;
 
 ## 1.3.0
+
 * Add support for the (new sentry gem)[https://github.com/getsentry/sentry-ruby].
 
 ## 1.2.0
+
 * Add `raven_log_size_limit` config option for limiting amount of data sent to sentry (defaults to `500_000`)
 
 ## 1.1.0
+
 * Add support for sentry and sidekiq
 
 ## 1.0.0
@@ -30,14 +32,12 @@ which ruins concept of single entry point :(. Also tied it to lamian instance
 
 * `e57e6cec` Changed rails dependency from `~> 4.2` to `>= 4.2`
 
-
 ## 0.3.1
 
 * 34ca83b5 Fixed formatting
 
 Stabilized formatting api, which removes control sequences from loggers data.
 E.g. `"[23mNice, lol[0m\n"` becomes `"Nice, lol\n"`
-
 
 ## 0.3.0
 
@@ -46,13 +46,13 @@ E.g. `"[23mNice, lol[0m\n"` becomes `"Nice, lol\n"`
 Updated API, so lamian is now forced to be used with block.
 It also simplified usage outside a middleware
 
-
 ## 0.2.0
+
 * `3166517e` Added integrtation with rails
 
 Injected middleware before `ExceptionNotification`, so `ExceptionNotification`
 can use current log without any configuration. Also added some views
 
-
 ## 0.1.0
+
 * `62eb8685` Made test version to check it's integration with rails application

--- a/lib/lamian.rb
+++ b/lib/lamian.rb
@@ -9,6 +9,7 @@ module Lamian
   autoload :Config, "lamian/config"
   autoload :Logger, "lamian/logger"
   autoload :LoggerExtension, "lamian/logger_extension"
+  autoload :LogDevice, "lamian/log_device"
   autoload :Middleware, "lamian/middleware"
   autoload :RavenContextExtension, "lamian/raven_context_extension"
   autoload :SidekiqRavenMiddleware, "lamian/sidekiq_raven_middleware"

--- a/lib/lamian/config.rb
+++ b/lib/lamian/config.rb
@@ -7,7 +7,7 @@ module Lamian
   # @attr formatter [Logger::Foramtter]
   #   formatter to use in lamian, global
   # @attr max_log_lines [Integer]
-  #   max number of log lines to log, defaults to 5000
+  #   max number of most recent log lines to store, defaults to 5000
   # @attr raven_log_size_limit [Integer]
   #   size limit when sending lamian log to sentry, defaults to +500_000+
   Config = Struct.new(:formatter, :max_log_lines, :raven_log_size_limit) do

--- a/lib/lamian/config.rb
+++ b/lib/lamian/config.rb
@@ -6,11 +6,14 @@ module Lamian
   # General lamian configuration class
   # @attr formatter [Logger::Foramtter]
   #   formatter to use in lamian, global
+  # @attr max_log_lines [Integer]
+  #   max number of log lines to log, defaults to 5000
   # @attr raven_log_size_limit [Integer]
   #   size limit when sending lamian log to sentry, defaults to +500_000+
-  Config = Struct.new(:formatter, :raven_log_size_limit) do
+  Config = Struct.new(:formatter, :max_log_lines, :raven_log_size_limit) do
     def initialize
       self.formatter = ::Logger::Formatter.new
+      self.max_log_lines = 5000
       self.raven_log_size_limit = 500_000
     end
   end

--- a/lib/lamian/log_device.rb
+++ b/lib/lamian/log_device.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "logger"
+
+module Lamian
+  # @api private
+  class LogDevice
+    def initialize(size = Lamian.config.max_log_lines)
+      self.size = size
+      self.lines = []
+    end
+
+    def write(string)
+      lines << string
+      lines.shift if lines.size > size
+      true
+    end
+
+    def string
+      lines.join
+    end
+
+    private
+
+    attr_accessor :size, :lines
+  end
+end

--- a/lib/lamian/logger.rb
+++ b/lib/lamian/logger.rb
@@ -23,8 +23,7 @@ module Lamian
     # @see Lamian.run
     # Collects logs sent inside block
     def run
-      logdevs.push(StringIO.new)
-
+      logdevs.push(Lamian::LogDevice.new)
       yield
     ensure
       logdevs.pop

--- a/spec/lamian/log_device_spec.rb
+++ b/spec/lamian/log_device_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+describe Lamian::LogDevice do
+  subject(:logdev) { described_class.new(10) }
+
+  it "saves log" do
+    logdev.write("Hello ")
+    logdev.write("world!")
+    expect(logdev.string).to eq("Hello world!")
+  end
+
+  it "limits log lines" do
+    15.times { logdev.write("hello") }
+    expect(logdev.string.scan(/hello/).size).to eq(10)
+  end
+end

--- a/spec/lamian/log_device_spec.rb
+++ b/spec/lamian/log_device_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Lamian::LogDevice do
-  subject(:logdev) { described_class.new(10) }
+  subject(:logdev) { described_class.new(5) }
 
   it "saves log" do
     logdev.write("Hello ")
@@ -9,8 +9,8 @@ describe Lamian::LogDevice do
     expect(logdev.string).to eq("Hello world!")
   end
 
-  it "limits log lines" do
-    15.times { logdev.write("hello") }
-    expect(logdev.string.scan(/hello/).size).to eq(10)
+  it "only stores 5 latest log lines" do
+    8.times { |x| logdev.write(x + 1) }
+    expect(logdev.string).to eq("45678")
   end
 end


### PR DESCRIPTION
Запилил кастомный LogDevice вместо StringIO, чтобы для больших джобок не хранить бесконечное количество логов в памяти.